### PR TITLE
Implement difficulty settings (#2)

### DIFF
--- a/config.py
+++ b/config.py
@@ -81,3 +81,25 @@ result_overlay_alpha = 120
 # Misc
 title = "Minesweeper"
 
+DIFFICULTIES = {
+    'easy': {'cols': 9, 'rows': 9, 'mines': 10},
+    'medium': {'cols': 16, 'rows': 16, 'mines': 40},
+    'hard': {'cols': 30, 'rows': 16, 'mines': 99}
+}
+
+def get_screen_size(c, r):
+    w = margin_left + c * cell_size + margin_right
+    h = margin_top + r * cell_size + margin_bottom
+    return (w, h)
+
+def apply_difficulty(level_key: str):
+    """Update global grid settings + derived window size for given difficulty key."""
+    global cols, rows, num_mines, width, height, display_dimension
+
+    settings = DIFFICULTIES[level_key]
+    cols = settings["cols"]
+    rows = settings["rows"]
+    num_mines = settings["mines"]
+
+    width, height = get_screen_size(cols, rows)
+    display_dimension = (width, height)

--- a/config.py
+++ b/config.py
@@ -84,7 +84,8 @@ title = "Minesweeper"
 DIFFICULTIES = {
     'easy': {'cols': 9, 'rows': 9, 'mines': 10},
     'medium': {'cols': 16, 'rows': 16, 'mines': 40},
-    'hard': {'cols': 30, 'rows': 16, 'mines': 99}
+    'hard': {'cols': 30, 'rows': 16, 'mines': 99},
+    'very_hard': {'cols': 30, 'rows': 24, 'mines': 150}  # 추가된 부분
 }
 
 def get_screen_size(c, r):

--- a/run.py
+++ b/run.py
@@ -245,6 +245,8 @@ class Game:
                     self.change_difficulty('medium')
                 elif event.key == pygame.K_3:
                     self.change_difficulty('hard')
+                elif event.key == pygame.K_4:     
+                    self.change_difficulty('very_hard')
             if event.type == pygame.MOUSEBUTTONDOWN:
                 self.input.handle_mouse(event.pos, event.button)
         if (self.board.game_over or self.board.win) and self.started and not self.end_ticks_ms:

--- a/run.py
+++ b/run.py
@@ -239,6 +239,12 @@ class Game:
             if event.type == pygame.KEYDOWN:
                 if event.key == pygame.K_r:
                     self.reset()
+                elif event.key == pygame.K_1:
+                    self.change_difficulty('easy')
+                elif event.key == pygame.K_2:
+                    self.change_difficulty('medium')
+                elif event.key == pygame.K_3:
+                    self.change_difficulty('hard')
             if event.type == pygame.MOUSEBUTTONDOWN:
                 self.input.handle_mouse(event.pos, event.button)
         if (self.board.game_over or self.board.win) and self.started and not self.end_ticks_ms:
@@ -247,6 +253,21 @@ class Game:
         self.clock.tick(config.fps)
         return True
 
+    def change_difficulty(self, level_key: str):
+        """난이도를 변경하고 게임을 재시작합니다."""
+        config.apply_difficulty(level_key)
+
+        # 창 크기 갱신
+        self.screen = pygame.display.set_mode(config.display_dimension)
+
+        # (선택) 타이틀에 난이도 표시
+        pygame.display.set_caption(f"{config.title} ({level_key})")
+
+        # 새 보드/렌더러로 교체 후 리셋
+        self.board = Board(config.cols, config.rows, config.num_mines)
+        self.renderer = Renderer(self.screen, self.board)
+
+        self.reset()
 
 def main() -> int:
     """Application entrypoint: run the main loop until quit."""


### PR DESCRIPTION
1. 개요
- 수정 내용: 사용자가 숫자 키 1, 2, 3을 눌러 실시간으로 난이도(Easy, Medium, Hard)를 선택하고 게임을 재시작할 수 있는 기능을 추가했습니다.

2. 주요 변경 사항

config.py : 
- 난이도별 설정값(DIFFICULTIES)을 딕셔너리로 정의했습니다 (Easy: 9x9, Medium: 16x16, Hard: 30x16).
- 난이도 변경 시 전역 변수(cols, rows, num_mines)와 창 크기를 업데이트하는 apply_difficulty 함수를 구현했습니다.

run.py:  
- run_step의 이벤트 루프에서 숫자 키 1, 2, 3 입력 시 해당 난이도로 변경되도록 로직을 추가했습니다.
- change_difficulty 메서드를 통해 Pygame 디스플레이 모드를 갱신하고, 새로운 보드와 렌더러를 생성하여 게임이 즉시 재설정되도록 했습니다.