### PR TITLE
Add hint key(#3)

### DIFF
--- a/components.py
+++ b/components.py
@@ -194,3 +194,32 @@ class Board:
             for cell in self.cells:
                 if not cell.state.is_revealed and not cell.state.is_mine:
                     cell.state.is_revealed = True
+
+    def reveal_random_safe_cell(self) -> bool:
+        """H키 힌트: 지뢰가 아닌, 아직 안 열린 칸 1개를 랜덤으로 '딱 1칸만' 엽니다."""
+        if self.game_over or self.win:
+            return False
+
+        # 지뢰가 아직 배치 안 됐으면(첫 행동이 H일 때) 먼저 배치
+        if not self._mines_placed:
+            c = random.randrange(self.cols)
+            r = random.randrange(self.rows)
+            self.place_mines(c, r)
+
+        # 후보: 안 열림 + 깃발 아님 + 지뢰 아님
+        candidates = [
+            cell for cell in self.cells
+            if (not cell.state.is_revealed) and (not cell.state.is_flagged) and (not cell.state.is_mine)
+        ]
+        if not candidates:
+            return False
+
+        pick = random.choice(candidates)
+
+        # "한 칸만" 열기: reveal() 호출 금지 (flood fill 방지)
+        pick.state.is_revealed = True
+        self.revealed_count += 1
+        self._check_win()
+        return True
+
+    

--- a/run.py
+++ b/run.py
@@ -239,6 +239,11 @@ class Game:
             if event.type == pygame.KEYDOWN:
                 if event.key == pygame.K_r:
                     self.reset()
+                elif event.key == pygame.K_h:
+                    if not self.started:
+                        self.started = True
+                        self.start_ticks_ms = pygame.time.get_ticks()
+                    self.board.reveal_random_safe_cell()
             if event.type == pygame.MOUSEBUTTONDOWN:
                 self.input.handle_mouse(event.pos, event.button)
         if (self.board.game_over or self.board.win) and self.started and not self.end_ticks_ms:

--- a/run.py
+++ b/run.py
@@ -239,7 +239,7 @@ class Game:
             if event.type == pygame.KEYDOWN:
                 if event.key == pygame.K_r:
                     self.reset()
-                elif event.key == pygame.K_h:
+                elif event.key == pygame.K_i:
                     if not self.started:
                         self.started = True
                         self.start_ticks_ms = pygame.time.get_ticks()


### PR DESCRIPTION
1. 개요
- 수정 내용: 게임 중 막막한 상황에서 사용자가 'H' 키를 눌러 지뢰가 없는 안전한 칸을 하나 확인할 수 있는 힌트 기능을 추가했습니다. 

2. 상세 변경 사항
components.py (Board 클래스):
- reveal_random_safe_cell() 메서드를 추가했습니다.
- 아직 열리지 않았고, 깃발이 꽂히지 않았으며, 지뢰가 아닌 셀들을 후보(candidates)로 추출하여 그중 하나를 무작위로 선택합니다.
- 힌트로 너무 많은 칸이 열리는 것을 방지하기 위해 reveal() 대신 상태값만 변경하여 반복적 오픈(Flood Fill) 없이 딱 1칸만 보이도록 처리했습니다.
- 게임 시작 전(첫 클릭 전) 힌트를 사용할 경우를 대비해 지뢰를 먼저 배치하는 로직을 포함했습니다. 
+2
run.py (Game 클래스):
- KEYDOWN 이벤트 핸들러에 K_h 입력을 추가했습니다. 
- 힌트 사용 시에도 게임 타이머가 정상적으로 시작되도록 로직을 구성했습니다.