### PR TITLE
Add high score save & display on game end (#4)

### DIFF
--- a/run.py
+++ b/run.py
@@ -261,7 +261,7 @@ class Game:
                 "BEST " + fmt_best(),
             ]
             if self.new_record:
-                lines.append("NEW RECORD!")
+                lines.append("BEST RECORD!")
             return "\n".join(lines)
 
         return None


### PR DESCRIPTION
1. 개요
- 수정 내용: 게임 기록을 로컬에 저장하고, 종료 시 현재 기록과 최고 기록(BEST)을 비교하여 표시하는 기능을 추가했습니다. 

2. 주요 변경 사항

데이터 영속성 (JSON):
- high_scores.json 파일을 통해 난이도별 최고 기록을 저장하고 불러오는 기능을 구현했습니다.
- _score_key()를 통해 보드 크기와 지뢰 수에 따라 별도의 기록이 관리되도록 설계했습니다.

Renderer 기능 확장:
- 기존의 단일 라인 출력 방식에서 \n(개행 문자)을 지원하는 다중 라인 렌더링 방식으로 draw_result_overlay를 개선했습니다.
- 결과 타이틀과 상세 스코어의 폰트 크기를 다르게 적용하여 가독성을 높였습니다.

게임 로직:
- 승리 시 현재 기록이 기존 BEST보다 빠를 경우 기록을 갱신하고 NEW RECORD! 메시지를 출력합니다.